### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,5 +1,8 @@
 name: Go Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/johnlam90/aws-multi-eni-controller/security/code-scanning/4](https://github.com/johnlam90/aws-multi-eni-controller/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimum required permissions for each job. For the `test` and `quality` jobs, the workflow primarily reads repository contents and uploads artifacts, so the `contents: read` permission is sufficient. If any job requires additional permissions, they will be explicitly added.

The `permissions` block will be added at the root level of the workflow to apply to all jobs, ensuring consistency and reducing redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
