### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-quality.yml
+++ b/.github/workflows/go-quality.yml
@@ -1,5 +1,8 @@
 name: Go Quality Checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/johnlam90/aws-multi-eni-controller/security/code-scanning/1](https://github.com/johnlam90/aws-multi-eni-controller/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
